### PR TITLE
Added timeout option as a command line argument.

### DIFF
--- a/webtrafficdump.pl
+++ b/webtrafficdump.pl
@@ -3,6 +3,10 @@ use strict;
 use warnings;
 use Parallel::ForkManager;
 
+my $MONITOR_INTERVAL;
+$MONITOR_INTERVAL = $ARGV[0] if defined $ARGV[0] && $ARGV[0] =~ m/^\d+$/;
+$MONITOR_INTERVAL ||= 10;
+my $NUM_RESULTS_TO_PRINT = 15;
 my $pm = Parallel::ForkManager->new(1);
 
 my $pid = $pm->start;
@@ -10,20 +14,18 @@ unless ($pid > 0) {
 	system("tcpdump -nnAi any '(dst port 80 or dst port 443) and tcp[32:4] = 0x47455420' -w /tmp/tcpdump.log");
 	$pm->finish(0, {});
 }
-print "Main thread going to sleep\n";
-sleep(10);
+#print "Main thread going to sleep\n";
+sleep($MONITOR_INTERVAL);
 print "[+] Sending kill signal to child\n";
 kill 15, $pid;
 $pm->wait_all_children;
 open(my $fh, "<", "/tmp/tcpdump.log");
-#$/ = "\n\n";
 
 my %IP;
 my %HOST;
 my %REQ;
 my %POST;
 my $capture = scalar qx{tcpdump -nnAr /tmp/tcpdump.log '(dst port 80 or dst port 443) and tcp[32:4] = 0x47455420'};
-my $c = 1;
 foreach my $line (split /\n\n/, $capture) {
 	if ($line =~ m/Host: (.*?)\n/ms) {
 		$HOST{$1}++;
@@ -34,21 +36,21 @@ foreach my $line (split /\n\n/, $capture) {
 		$IP{$ip}++;
 	};
 	if ($line =~ m/HTTP: GET (.*?) HTTP.*Host: (.*?)\n/ms){
-		#my $var = "$2$1";
 		$REQ{"$2$1"}++;
 	};
 	if ($line =~ m/HTTP: POST (.*?) HTTP.*Host: (.*?)\n/ms) {
 		$POST{"$2$1"}++;
 	}
-#print "$c ------> $line";
-#$c++;
 };
 
 sub printit {
 	my $full_hash = shift;
 	my %full_hash = %$full_hash;
+	my $c = $NUM_RESULTS_TO_PRINT;
 	foreach my $value (sort { $full_hash{$b} <=> $full_hash{$a} } keys %full_hash) {
+		last if $c <= 0;
 		printf "  %10d  %s\n", $full_hash{$value}, $value;
+		$c--;
 	}
 
 };


### PR DESCRIPTION
The MONITOR_INTERVAL variable determines how long tcpdump captures the traffic. By default, its 10seconds.